### PR TITLE
correções de texto no site

### DIFF
--- a/docpad.js
+++ b/docpad.js
@@ -73,21 +73,21 @@ module.exports = {
         name: "Denise Motta Dau",
         photo: "themes/yellow-swan/img/denise.jpg",
         bio: "Secretaria Denise Motta Dau e representantes dos grupos vencedores do Prêmio Mulheres Tech em Sampa",
-        company: "Secretaria de Políticas para Mulheres",
+        company: "Denise Motta Dau/ SMPM",
         // link: {
         //   href: "http://twitter.com/linus",
         //   text: "@linus"
         // },
         presentation: {
           title: "Palestra de abertura",
-          description: "[Jardim] Apresentação dos projetos vencedores do Prêmio.",
+          description: "[Jardim] A Secretaria da Secretaria Municipal de Políticas para as Mulheres abre o evento e apresenta os projetos vencedores da 2a edição do Prêmio Mulheres Tech em Sampa. Duração: 1h",
           time: "09h30"
         }
       },
       {
         name: "Gedeane Kenshima",
         photo: "themes/yellow-swan/img/gedeane.jpg",
-        bio: "Gedeane Kenshima é engenheira de controle e automação, técnica em automação industria, ambos pelo IFSP. Trabalha como montadora na Tudela Indústria. Hobbista e maker, vem desenvolvendo projetos com arduíno em 2013 e wearables desde 2015. Os eletrônicos desenvolvidos são voltados para a área de moda e entretenimento.",
+        bio: "Gedeane Kenshima é engenheira de controle & automação e técnica em automação industrial, ambos pelo IFSP. Trabalha como montadora na Tudela Indústria. Hobbista e maker, vem desenvolvendo projetos com arduíno desde 2013 e wearables desde 2015. Os eletrônicos desenvolvidos são voltados para a área de moda e entretenimento.",
         company: "",
         // link: {
         //   href: "http://github.com/billy95",
@@ -95,12 +95,12 @@ module.exports = {
         // },
         presentation: {
           title: "Arduíno para meninas",
-          description: "[Sala 3T] Nesse workshop serão apresentados conceitos básicos de programação voltado à experimentações em arduíno. A atividade é voltada para meninas e adolescentes a partir de 9 anos (8 vagas). Duração: 1h 30m.",
+          description: "[Sala 3 Térreo] Nesse workshop serão apresentados conceitos básicos de programação voltado a experimentações em arduíno. A atividade, patrocinada pela Tato Equipamentos e pela GBK Robotics, é voltada para meninas e adolescentes a partir de 9 anos (8 vagas). Duração: 1h30m.",
           time: "10h30"
         }
       },
       {
-        name: "Priscila Zillo",
+        name: "Priscila Amaral Zillo",
         photo: "themes/yellow-swan/img/priscila.jpg",
         bio: "Priscila Amaral Zillo é CEO do Curso Sapientia, empresa de e-learning que prepara diplomatas para concurso público. O Sapientia tem investido em tecnologia e soluções criativas para crescer em um mercado em crise.",
         company: "Sapientia",
@@ -109,15 +109,15 @@ module.exports = {
         //   text: "@billy95"
         // },
         presentation: {
-          title: "Tecnologia e mudanças na organização do trabalho",
-          description: "[Sala 1A] A Revolução Industrial foi uma revolução lenta e, de certa maneira, silenciosa, mas com profundos impactos sociais e na organização do trabalho. Alguns especialistas identificam a nossa época com a Quarta Revolução Industrial, muito mais rápida comparada às outras 3 em termos do ritmo de mudanças. A CEO do Curso Sapientia fala sobre inovação na área de e-learning tendo como mercado um público-alvo conservador (ou seja, resistente à tecnologia), de projetos de tecnologia na empresa e do uso das redes sociais para promoção do trabalho. O trabalho à frente do Sapientia é um caso de estudo para falar de mudanças mais amplas na organização do trabalho. Duração: 1h.",
+          title: "Tecnologia e redes sociais no Ensino à Distância",
+          description: "[Sala 1o Andar]  Nessa palestra, a CEO do Curso Sapientia, Priscila Amaral Zillo, fala sobre inovação na área de Educação, de projetos de tecnologia em sua empresa, de marketing digital e uso das redes sociais na área de e-learning. Duração: 40 min",
           time: "10h30"
         }
       },
       {
-        name: "Amanda Pinheiro",
+        name: "Amanda Gomes Pinheiro",
         photo: "themes/yellow-swan/img/amanda.jpg",
-        bio: "Amanda Gomes Pinheiro é fundadora da AMG Inovação, Comunicação e Desenvolvimento, empresa que atua no desenvolvimento de empreendedores e líderes em todo o Brasil.Formada em Administração de Empresas, com pós-graduacão em Varejo pela Fia USP e MBA em Estratégia Empresarial, é tambeem especialista em comportamento humano e coach. Abriu sua primeira empresa aos 21 anos e liderou funções estratégicas ao longo de 18 anos em grandes empresas de segmentos como tecnologia da informação, telecom, indústria, finanças e varejo.",
+        bio: "Amanda Gomes Pinheiro é fundadora da AMG Inovação, Comunicação e Desenvolvimento, empresa que atua no desenvolvimento de empreendedores e líderes em todo o Brasil.Formada em Administração de Empresas, com pós-graduacão em Varejo pela Fia USP e MBA em Estratégia Empresarial, é também especialista em comportamento humano e coach. Abriu sua primeira empresa aos 21 anos e liderou funções estratégicas ao longo de 18 anos em grandes empresas de segmentos como tecnologia da informação, telecom, indústria, finanças e varejo.",
         company: "",
         // link: {
         //   href: "http://github.com/billy95",
@@ -125,22 +125,22 @@ module.exports = {
         // },
         presentation: {
           title: "Tecnologia e empreendedorismo",
-          description: "[Sala 1T] Orientação a mulheres que querem assumir os desafios de empreender e liderar com mais assertividade, segurança e êxito. Duração: 1h.",
-          time: "11h30"
+          description: "[Sala 1 Térreo] Orientação a mulheres que querem assumir os desafios de empreender e liderar com mais assertividade, segurança e êxito. Duração: 1h.",
+          time: "11h00"
         }
       },
       {
         name: "Malu Andrade",
         photo: "themes/yellow-swan/img/malu.jpg",
         bio: "Malu Andrade é coordenadora de Inovação da Spcine. Mestranda em arquivos audiovisuais em plataformas digitais pela USP e especialização em Estéticas Tecnológicas pela PUC. Trabalha com gestão cultural há 10 anos, tendo se dedicado desde 2010 a cultura digital.",
-        company: "SP Cine (WUG)",
+        company: "SPCine",
         // link: {
         //   href: "http://github.com/billy95",
         //   text: "@billy95"
         // },
         presentation: {
           title: "Políticas públicas e gênero feminino nos games",
-          description: "[Sala 1A] A palestra abordará os seguintes temas: Política de inovação da SPcine - LEIA e política para games. Políticas públicas para games no Brasil. Participação da mulher no audiovisual no país. Duração: 30m.",
+          description: "[Sala 1o Andar] A palestra abordará os seguintes temas: Política de inovação da SPcine - LEIA e política para games. Políticas públicas para games no Brasil. Participação da mulher no audiovisual no país. Duração: 30m.",
           time: "11h00"
         }
       },
@@ -159,7 +159,7 @@ module.exports = {
         // },
         presentation: {
           title: "Competição de Fliperama (Street Fighter)",
-          description: "[Sala 2T] Quer se juntar a um monte de mulheres e jogar aquele game da infância e adolescência no fliperama? Então participe da competição de Street Fighter só para elas. Venha conhecer nosso arcade inteiramente montado por nós e saber das nossas Oficinas. Duração: 1h.",
+          description: "[Sala 2 Térreo] Quer se juntar a um monte de mulheres e jogar aquele game da infância e adolescência no fliperama? Então participe da competição de Street Fighter só para elas. Venha conhecer nosso arcade inteiramente montado por nós e saber das nossas Oficinas. Duração: 1h.",
           time: "13h30"
         }
       },
@@ -174,7 +174,7 @@ module.exports = {
         // },
         presentation: {
           title: "Mostra de arte e Workshop de ilustração básica",
-          description: "[Sala 1T] #Empoderadas é o nome desse workshop. Personagens femininas de games que foram criadas de forma sexualizada ou como \"donzelas\" serão desenhadas e transformadas, pela artista e ilustradora Bi Aguilart, em figuras humanizadas e empoderadas. Duração: 1h 30m.",
+          description: "[Sala 1 Térreo] #Empoderadas é o nome desse workshop. Personagens femininas de games que foram criadas de forma sexualizada ou como \"donzelas\" serão desenhadas e transformadas, pela artista e ilustradora Bi Aguilart, em figuras humanizadas e empoderadas. Duração: 1h 30m.",
           time: "15h00"
         }
       },
@@ -188,8 +188,8 @@ module.exports = {
           text: "@vanessametonini"
         },
         presentation: {
-          title: "Workshop de Web design",
-          description: "[Sala 3T] O que é? Como ingressar na carreira? Como montar meu site? Duração: 2hs.",
+          title: "Workshop de Web Design",
+          description: "[Sala 3 Térreo] O que é? Como ingressar na carreira? Como montar meu site? Duração: 2h.",
           time: "15h00"
         }
       },
@@ -204,7 +204,7 @@ module.exports = {
         // },
         presentation: {
           title: "O que você vai ser quando você crescer?",
-          description: "[Sala 1A] Apresentação focada nas escolhas profissionais com base no sistema de ensino atual. Sobre a raiz dos problemas do porque as mulheres não estão escolhendo a área de tecnologia. Como as meninas são preparadas e inspiradas e qual a disruptura no mercado quando ela cresce serão tópicos abordados. Duração: 30m.",
+          description: "[Sala 1o Andar] Apresentação focada nas escolhas profissionais femininas, tendo em vista o sistema de ensino atual. Discute a raiz dos problemas que explicam por que as mulheres não estão escolhendo a área de tecnologia. Como as meninas são preparadas e inspiradas e qual a disruptura no mercado quando ela cresce serão tópicos abordados. Duração: 25 m.",
           time: "15h00"
         }
       },

--- a/docpad.js
+++ b/docpad.js
@@ -21,7 +21,7 @@ module.exports = {
     // The Call To Action button at the header,
     // If you don't want this, just remove the callToAction property.
     callToAction: {
-        text: "Inscreva-se!",
+        text: "Inscreva-se para participar do evento!",
         link: "https://www.eventbrite.com.br/e/mulheres-tech-day-tickets-22072708064"
     },
 
@@ -95,7 +95,7 @@ module.exports = {
         // },
         presentation: {
           title: "Arduíno para meninas",
-          description: "[Sala 3 Térreo] Nesse workshop serão apresentados conceitos básicos de programação voltado a experimentações em arduíno. A atividade, patrocinada pela Tato Equipamentos e pela GBK Robotics, é voltada para meninas e adolescentes a partir de 9 anos (8 vagas). Duração: 1h30m.",
+          description: "[Sala 3 Térreo] Nesse workshop organizado pelo MariaLab serão apresentados conceitos básicos de programação voltado a experimentações em arduíno. A atividade, patrocinada pela Tato Equipamentos e pela GBK Robotics, é voltada para meninas e adolescentes a partir de 9 anos (8 vagas). Duração: 1h30m.",
           time: "10h30"
         }
       },
@@ -132,7 +132,7 @@ module.exports = {
       {
         name: "Malu Andrade",
         photo: "themes/yellow-swan/img/malu.jpg",
-        bio: "Malu Andrade é coordenadora de Inovação da Spcine. Mestranda em arquivos audiovisuais em plataformas digitais pela USP e especialização em Estéticas Tecnológicas pela PUC. Trabalha com gestão cultural há 10 anos, tendo se dedicado desde 2010 a cultura digital.",
+        bio: "Malu Andrade é coordenadora de Inovação da SpCine. Mestranda em arquivos audiovisuais em plataformas digitais pela USP e especialização em Estéticas Tecnológicas pela PUC. Trabalha com gestão cultural há 10 anos, tendo se dedicado desde 2010 a cultura digital.",
         company: "SPCine",
         // link: {
         //   href: "http://github.com/billy95",
@@ -140,12 +140,12 @@ module.exports = {
         // },
         presentation: {
           title: "Políticas públicas e gênero feminino nos games",
-          description: "[Sala 1o Andar] A palestra abordará os seguintes temas: Política de inovação da SPcine - LEIA e política para games. Políticas públicas para games no Brasil. Participação da mulher no audiovisual no país. Duração: 30m.",
-          time: "11h00"
+          description: "[Sala 1o Andar] A palestra abordará os seguintes temas: Política de inovação da SpCine - LEIA e política para games. Políticas públicas para games no Brasil. Participação da mulher no audiovisual no país. Duração: 30m.",
+          time: "11h30"
         }
       },
       {
-        name: "Almoço",
+        name: "Break",
         time: "12h00"
       },
       {
@@ -159,7 +159,7 @@ module.exports = {
         // },
         presentation: {
           title: "Competição de Fliperama (Street Fighter)",
-          description: "[Sala 2 Térreo] Quer se juntar a um monte de mulheres e jogar aquele game da infância e adolescência no fliperama? Então participe da competição de Street Fighter só para elas. Venha conhecer nosso arcade inteiramente montado por nós e saber das nossas Oficinas. Duração: 1h.",
+          description: "[Sala 2 Térreo] Quer se juntar a um monte de mulheres e jogar aquele game da infância e adolescência no fliperama? Então participe da competição de Street Fighter só para elas. Venha conhecer nosso arcade inteiramente montado por nós e saber das nossas Oficinas. Duração: 1h30",
           time: "13h30"
         }
       },
@@ -174,7 +174,7 @@ module.exports = {
         // },
         presentation: {
           title: "Mostra de arte e Workshop de ilustração básica",
-          description: "[Sala 1 Térreo] #Empoderadas é o nome desse workshop. Personagens femininas de games que foram criadas de forma sexualizada ou como \"donzelas\" serão desenhadas e transformadas, pela artista e ilustradora Bi Aguilart, em figuras humanizadas e empoderadas. Duração: 1h 30m.",
+          description: "[Sala 1 Térreo] #Empoderadas é o nome desse workshop. Personagens femininas de games que foram criadas de forma sexualizada ou como \"donzelas\" serão desenhadas e transformadas, pela artista e ilustradora Bi Aguilart, em figuras humanizadas e empoderadas. Duração: 1h30",
           time: "15h00"
         }
       },
@@ -209,23 +209,23 @@ module.exports = {
         }
       },
       {
-        name: "Programaria",
+        name: "Iana Chan",
         //photo: "themes/yellow-swan/img/taty-barros.jpg",
-        //bio: "",
+        bio: "Iana Chan é jornalista e fundadora da PrograMaria, iniciativa que tem a missão de empoderar mulheres por meio da tecnologia e da programação. Também é Community Manager na Liga Ventures.",
         company: "Programaria",
         // link: {
         //   href: "http://github.com/stevie",
         //   text: "@stevie"
         // },
         presentation: {
-          title: "Programaria",
-          description: "[Sala 1A] Duração: 1h.",
+          title: "Campanha #SerMulherEmTech",
+          description: "[Sala 1o Andar] Ser mulher é um desafio imenso. Ser mulher na área de tecnologia traz algumas dificuldades peculiares. Nessa conversa vamos discutir as barreiras que afastam as mulheres da área e o que precisa ser feito para mudar esse cenário. Duração: 40 min.",
           time: "15h30"
         }
       },
       {
-        name: "Coffee-break",
-        time: "16h00"
+        name: "PyLadies e o que é Python",
+        time: "16h20"
       },
       {
         name: "Encerramento",

--- a/docpad.js
+++ b/docpad.js
@@ -132,7 +132,7 @@ module.exports = {
       {
         name: "Malu Andrade",
         photo: "themes/yellow-swan/img/malu.jpg",
-        bio: "Malu Andrade é coordenadora de Inovação da SpCine. Mestranda em arquivos audiovisuais em plataformas digitais pela USP e especialização em Estéticas Tecnológicas pela PUC. Trabalha com gestão cultural há 10 anos, tendo se dedicado desde 2010 a cultura digital.",
+        bio: "Malu Andrade é coordenadora de Inovação da SpCine. Mestranda em arquivos audiovisuais em plataformas digitais pela USP e especialização em Estéticas Tecnológicas pela PUC. Trabalha com gestão cultural há 10 anos, tendo se dedicado à cultura digital desde 2010.",
         company: "SPCine",
         // link: {
         //   href: "http://github.com/billy95",


### PR DESCRIPTION
Não consegui adicionar a descrição da atividade das PyLadies e mudar o logo do SP Negócios (É Tech Sampa o correto).

Descrição da atividade PyLadies:

![image](https://cloud.githubusercontent.com/assets/16233817/13299563/6ce67546-db1a-11e5-97f6-dddd03ee8f9e.png)
